### PR TITLE
It's "plexsolutions", not "plexsystems".

### DIFF
--- a/assets.sh
+++ b/assets.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-declare -r      repository=plexsystems/readhook
+declare -r      repository=plexsolutions/readhook
 declare -r -a   assets=(basehook.so fullhook.so noophook.so nullhook.so)
 declare         tag=$1
 


### PR DESCRIPTION
The next commit will likely be to obsolete assets.sh, but I am pulling this change the corrects the organization name, in the interest of completeness.